### PR TITLE
Updated .env and added docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ FROM    node:10.16.3-alpine
 
 WORKDIR /src
 COPY    src ./
-RUN     touch .env
 
 # Delete yarn and node_modules, re-run npm install before deleting npm
 RUN     rm -rf ./node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,6 @@ COPY    healthcheck.js /etc/health/
 HEALTHCHECK --interval=10s --timeout=3s CMD ["node", "/etc/health/healthcheck"]
 
 # Expose the service port
-EXPOSE  3000
+EXPOSE  80 3000
 
 CMD  ["node", "server.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,16 @@ WORKDIR /src
 COPY    src ./
 RUN     touch .env
 
-RUN     rm -rf /usr/local/bin/yarn /usr/local/bin/npm /usr/local/bin/yarnpkg
-COPY    healthcheck.js /etc/health/
+# Delete yarn and node_modules, re-run npm install before deleting npm
+RUN     rm -rf ./node_modules
+RUN		npm install --unsafe-perm
+RUN		rm -rf /usr/local/bin/npm /usr/local/bin/yarn /usr/local/bin/yarnpkg
 
+# Setup healthcheck
+COPY    healthcheck.js /etc/health/
 HEALTHCHECK --interval=10s --timeout=3s CMD ["node", "/etc/health/healthcheck"]
 
 # Expose the service port
-EXPOSE  80
+EXPOSE  3000
 
-CMD  ["node", "index.js"]
+CMD  ["node", "server.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,9 +5,11 @@ services:
     ports:
       - "3000:3000"
     environment:
-      DB_CONN: "mongodb://mongo:27017"
       API_PORT: 3000
+      DB_CONN: "mongodb://mongo:27017"
+      DB_NAME: "traceph"
+      HASH_KEY: "DEV_HASH_KEY"
   mongo:
     image: mongo:4.2.5
     ports:
-      - "27017:27017"
+      - "27017-27019:27017-27019"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "3.1"
+services:
+  api:
+    build: .
+    ports:
+      - "3000:3000"
+    environment:
+      DB_CONN: "mongodb://mongo:27017"
+      API_PORT: 3000
+  mongo:
+    image: mongo:4.2.5
+    ports:
+      - "27017:27017"

--- a/healthcheck.js
+++ b/healthcheck.js
@@ -1,18 +1,19 @@
-const http = require("http");
+const http = require('http');
+
+const { API_PORT } = process.env;
 
 const options = {
-	hostname : "0.0.0.0",
-	port : "80",
-	timeout : 3000,
+	hostname: '0.0.0.0',
+	port: API_PORT,
+	timeout: 3000,
 	path: '/healthcheck',
 	method: 'GET'
 };
 
-const request = http.request(options, (res) => {
+const request = http.request(options, res => {
 	if (res.statusCode == 200) {
 		process.exit(0);
-	}
-	else {
+	} else {
 		process.exit(1);
 	}
 });

--- a/src/.env.example
+++ b/src/.env.example
@@ -1,5 +1,4 @@
-API_URL=localhost:3000
 API_PORT=3000
-DB_CONN=mongodb://localhost:27107/traceph
-TEST_DB_CONN=mongodb://localhost:27017/test-traceph
+DB_CONN=mongodb://localhost:27017
+DB_NAME=traceph
 HASH_KEY=A85A30E5-93F3-42AE-86EB-33BFD8133597

--- a/src/configs/database.config.js
+++ b/src/configs/database.config.js
@@ -3,9 +3,10 @@
 const mongoose = require('mongoose');
 const logger = require('~logger');
 
+const { DB_CONN, DB_NAME } = process.env;
+
 const config = (opts = {}) => {
-	const uri =
-		process.env.DATABASE_CONNECTION || 'mongodb://localhost:27017/traceph';
+	const uri = getConnectionUrl(false);
 	mongoose
 		.connect(
 			uri,
@@ -15,6 +16,16 @@ const config = (opts = {}) => {
 		.catch(err => logger.error(`Database error: ${err.message}`));
 };
 
+const getConnectionUrl = (forTest = false) => {
+	const host = `${DB_CONN || 'mongodb://localhost:27017'}`.replace(/\/$/, '');
+	const dbName = DB_NAME || 'traceph';
+	if(forTest) {
+		return `${host}/test-${dbName}`
+	}
+	return `${host}/${dbName}`;
+}
+
 module.exports = {
-	config
+	config,
+	getConnectionUrl
 };

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,6 @@
 require('dotenv-safe').config();
 require('./configs/database.config').config();
 
-const { API_PORT, API_URL } = process.env;
 const express = require('express');
 const bodyParser = require('body-parser');
 const Routes = require('./routes');

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -7,8 +7,14 @@ const NodeContactsRoute = require('./node-contacts.route');
 
 const BASE_ROUTE = '/api';
 module.exports = server => {
-  server.use('/docs', DocsRoute);
   server.use(BASE_ROUTE + '/device', DeviceRoute);
   server.use(BASE_ROUTE + '/node', NodeRoute);
   server.use(BASE_ROUTE + '/node_contacts', NodeContactsRoute);
+  
+  // !DO NOT REMOVE OR EDIT BEYOND THIS LINE!
+  server.use('/docs', DocsRoute);
+	server.get('/healthcheck', (req, res, next) => {
+		res.status(200).send('OK');
+		return next();
+	});
 };

--- a/src/test/device.test.js
+++ b/src/test/device.test.js
@@ -1,12 +1,13 @@
 const mongoose = require("mongoose");
-const server = require("../index");
+const server = require("~/index");
 const request = require("supertest");
+const { getConnectionUrl } = require("~/configs/database.config");
 
 const Device = require('../models/device.model');
 
 beforeAll(async () => {
-  const url = process.env.TEST_DB_CONN || 'mongodb://localhost:27017/test-traceph';
-  await mongoose.connect(url, { useNewUrlParser: true });
+	const url = getConnectionUrl(true);
+	await mongoose.connect(url, { useNewUrlParser: true });
 });
 
 describe('Device', () => {

--- a/src/test/node.test.js
+++ b/src/test/node.test.js
@@ -1,11 +1,12 @@
 const mongoose = require("mongoose");
 const server = require("../index");
 const request = require("supertest");
+const { getConnectionUrl } = require("~/configs/database.config")
 
 const Node = require('../models/nodes.model');
 
 beforeAll(async () => {
-  const url = process.env.TEST_DB_CONN || 'mongodb://localhost:27017/test-traceph';
+	const url = getConnectionUrl(true);
   await mongoose.connect(url, { useNewUrlParser: true });
 });
 


### PR DESCRIPTION
This PR contains the following changes:

- 🎨 Updated environment variables in `.env.example`.

    ```properties
    API_PORT=3000
    DB_CONN=mongodb://localhost:27017
    DB_NAME=traceph
    HASH_KEY=A85A30E5-93F3-42AE-86EB-33BFD8133597
    ```

- 🎨 Updated files affected by `.env` change. ([6e8599a](https://github.com/trace-ph/node-api/commit/6e8599abb7ce0849c3d531e7bc33d625856f5e65))
- ✨ Added `/healthcheck` endpoint.
- ✨ Added `docker-compose.yml` for easier `mongodb` and `api` provisioning.
    - For easier API deployment for frontend dev testing, `docker-compose` will run and provision a container for the api and MongoDB by running:

    ```
    docker-compose -p traceph up -d --build
    ```
    - API wil be available in port `3000` and mongodb will be available in ports `27017-27019`
    - To provision just the MongoDB container run:
    ```
    docker-compose -p traceph up -d mongo
    ```