### PR TITLE
:art: Updated node_id Generation

### DIFF
--- a/src/controllers/node-contacts.controller.js
+++ b/src/controllers/node-contacts.controller.js
@@ -9,9 +9,6 @@ const createContacts = (request, response) => {
       contacts.map((contact) => ({
         ...contact,
 
-        // Sort node pairs
-        node_pairs: contact.node_pairs.sort(),
-
         // Get ip from the server
         ip: request.header('x-forwarded-for') || request.connection.remoteAddress,
       })),

--- a/src/controllers/node-contacts.controller.js
+++ b/src/controllers/node-contacts.controller.js
@@ -9,8 +9,10 @@ const createContacts = (request, response) => {
       contacts.map((contact) => ({
         ...contact,
 
+        node_pairs: [contact.source_node_id, contact.node_pair].sort(),
         // Get ip from the server
-        ip: request.header('x-forwarded-for') || request.connection.remoteAddress,
+        ip:
+          request.header('x-forwarded-for') || request.connection.remoteAddress,
       })),
     )
     .then((result) => response.send(result))

--- a/src/models/node-contact.model.js
+++ b/src/models/node-contact.model.js
@@ -19,7 +19,7 @@ const NodeContactSchema = new Schema(
 
     // As per TOR the pairings must be stored such that node_id_a < node_id_b.
     // A node_pair with a single data is allowed to handle 'Indirect' contact. See TOR 2c.
-    node_pair: { type: Schema.Types.String, required: true },
+    node_pairs: [{ type: Schema.Types.String, required: true }],
 
     rssi: { type: Schema.Types.Number, required: true },
 

--- a/src/models/node-contact.model.js
+++ b/src/models/node-contact.model.js
@@ -19,7 +19,11 @@ const NodeContactSchema = new Schema(
 
     // As per TOR the pairings must be stored such that node_id_a < node_id_b.
     // A node_pair with a single data is allowed to handle 'Indirect' contact. See TOR 2c.
-    node_pairs: [{ type: Schema.Types.String, required: true }],
+    node_pair: { type: Schema.Types.String, required: true },
+
+    rssi: { type: Schema.Types.Number, required: true },
+
+    txPower: { type: Schema.Types.Number, required: true },
 
     // Location stored in GeoJSON format
     location: {

--- a/src/models/nodes.model.js
+++ b/src/models/nodes.model.js
@@ -8,8 +8,6 @@ const NodeSchema = new Schema(
     node_id: { type: Schema.Types.String, required: true },
 
     device_id: { type: Schema.Types.String, required: true },
-
-    person_id: { type: Schema.Types.String, required: true },
   },
   {
     timestamps: { createdAt: 'created_at', updatedAt: 'updated_at' },

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -8066,11 +8066,6 @@
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
-    "uuid": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
-      "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg=="
-    },
     "v8-compile-cache": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",

--- a/src/package.json
+++ b/src/package.json
@@ -40,7 +40,6 @@
     "morgan": "^1.10.0",
     "require-directory": "^2.1.1",
     "undefsafe": "^2.0.3",
-    "uuid": "^7.0.2",
     "winston": "^3.2.1"
   },
   "devDependencies": {

--- a/src/services/node.service.js
+++ b/src/services/node.service.js
@@ -1,16 +1,17 @@
 /* eslint camelcase: 0 */
 
-const { v5: uuidv5, v4: uuidv4 } = require('uuid');
+const crypto = require('crypto');
+const { v4: uuidv4 } = require('uuid');
 const Node = require('~models/nodes.model');
 const logger = require('~logger');
 
 const save = async (device_id) => {
   logger.info(`Creating new node for device id {${device_id}}`);
   const node = { device_id, person_id: uuidv4() };
-  node.node_id = uuidv5(
-    `${device_id}${node.person_id}`,
-    process.env.HASH_KEY,
-  );
+  node.node_id = crypto.createHmac('sha256', process.env.HASH_KEY)
+    .update(`${device_id}${node.person_id}`)
+    .digest('hex')
+    .substr(0, 15);
   return new Node(node).save();
 };
 

--- a/src/services/node.service.js
+++ b/src/services/node.service.js
@@ -1,15 +1,14 @@
 /* eslint camelcase: 0 */
 
 const crypto = require('crypto');
-const { v4: uuidv4 } = require('uuid');
 const Node = require('~models/nodes.model');
 const logger = require('~logger');
 
 const save = async (device_id) => {
   logger.info(`Creating new node for device id {${device_id}}`);
-  const node = { device_id, person_id: uuidv4() };
+  const node = { device_id };
   node.node_id = crypto.createHmac('sha256', process.env.HASH_KEY)
-    .update(`${device_id}${node.person_id}`)
+    .update(device_id)
     .digest('hex')
     .substr(0, 15);
   return new Node(node).save();

--- a/src/validators/node-contacts.validator.js
+++ b/src/validators/node-contacts.validator.js
@@ -26,12 +26,20 @@ const nodeSchema = {
 
           source_node_id: joi
             .string()
-            .guid()
+            .max(15)
             .required(),
 
-          node_pairs: joi
-            .array()
-            .items(joi.string().guid())
+          node_pair: joi
+            .string()
+            .max(15)
+            .required(),
+
+          rssi: joi
+            .number()
+            .required(),
+
+          txPower: joi
+            .number()
             .required(),
 
           location: joi

--- a/src/validators/node.validator.js
+++ b/src/validators/node.validator.js
@@ -3,7 +3,6 @@
 const joi = require('@hapi/joi');
 
 const MAC_ADDRESS_REGEX = /^(?:[0-9a-fA-F]{2}\:){5}[0-9a-fA-F]{2}$/;
-const UUID_REGEX = /^[0-9a-fA-F]{8}\-(?:(?:[0-9a-fA-F]{4}\-){3})[0-9a-fA-F]{12}$/;
 
 const nodeSchema = {
   POST: joi
@@ -20,15 +19,11 @@ const nodeSchema = {
     .object({
       node_id: joi
         .string()
-        .pattern(UUID_REGEX)
+        .max(15)
         .required(),
       device_id: joi
         .string()
         .pattern(MAC_ADDRESS_REGEX)
-        .required(),
-      person_id: joi
-        .string()
-        .pattern(UUID_REGEX)
         .required(),
     })
     .messages({
@@ -36,11 +31,10 @@ const nodeSchema = {
     }),
   GET: joi
     .object({
-      node_id: joi.string().pattern(UUID_REGEX),
+      node_id: joi.string().max(15),
       device_id: joi.string().pattern(MAC_ADDRESS_REGEX),
-      person_id: joi.string().pattern(UUID_REGEX),
     })
-    .or('node_id', 'device_id', 'person_id')
+    .or('node_id', 'device_id')
     .messages({
       'string.pattern.base': '{#key} has an invalid format: "{#value}"',
     }),


### PR DESCRIPTION
This PR includes the following changes:
- 🎨 Updated implementation of creating `node_id`.
    - Used `crypto` library to hash `device_id` + `person_id` then truncated string to 15 characters.
- 🎨 Updated `node-contact` model.
    - Renamed `node_pairs` to `node_pair` and set type to `String`.
    - Added `rssi` and `txPower` props.